### PR TITLE
[Issue: #6] Added pipeline for automated docs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: Auto-Generate Docs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  generate-javadoc:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 20
+      uses: actions/setup-java@v3
+      with:
+        java-version: '20'
+
+    - name: Create docs directory if it doesn't exist
+      run: mkdir -p ./docs
+
+    - name: Generate Javadoc
+      run: mvn javadoc:javadoc       
+
+    - name: Switch to clean docs-deployment branch
+      run: |
+        git branch -d docs-deployment     
+        git switch --create docs-deployment
+
+    - name: Clean up
+      run: rm -rf ./src pom.xml ./target
+
+    - name: Commit and push Javadoc to docs-deployment branch
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add .
+        git commit -m "Update Javadoc for release ${{ github.event.release.tag_name }}"
+        git push origin docs-deployment

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.tinf</groupId>
@@ -35,6 +35,17 @@
                         <version>5.10.2</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <reportOutputDirectory>${project.basedir}/docs</reportOutputDirectory>
+                    <show>public</show>
+                    <author>true</author>
+                    <version>true</version>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Description of Changes

Added new functionality to the release pipeline to auto-generate java docs when a new release is created.

## Verify

- [x] The PR does not involve breaking changes, or the corresponding developers are informed and mentioned under "Reference"
- [x] Unit tests were added if needed
- [ ] The code that is being added, was tested and no faults were found
- [x] The code that is being added, does not require external dependencies

## Reference
- #6 
- FYI: @habetuz , could involve breaking changes

## Additional Context

When the workflow is triggered, it creates a ./docs folder and generates a java documentation using `maven` and `javadoc` inside. 

The newly created doc is then copied over to a branch called `docs-deployment` , from which it can later be deployed to GitHub Pages solely 
