### PR TITLE
feat!: Add primitive type support to array utils

### DIFF
--- a/release.md
+++ b/release.md
@@ -1,3 +1,3 @@
-# File Utilities
+# Primitive types support for array utilities
 
-This update added many array utilities.
+This update adds primitive type support to array utilities.

--- a/release.md
+++ b/release.md
@@ -1,3 +1,5 @@
 # Primitive types support for array utilities
 
 This update adds primitive type support to array utilities.
+
+Additionally all methods previously following a wrong naming convention (pascal case for static functions) now follow the java naming convention of camel case.

--- a/src/main/java/de/tinf/collections/ArrayUtils.java
+++ b/src/main/java/de/tinf/collections/ArrayUtils.java
@@ -224,8 +224,8 @@ public class ArrayUtils {
      * @param element the element to append
      * @return the modified array with the element appended
      */
-    public static byte[] Append(byte[] array, byte element) {
-        return toPrimitiveArray(Append(toObjectArray(array), element));
+    public static byte[] append(byte[] array, byte element) {
+        return toPrimitiveArray(append(toObjectArray(array), element));
     }
 
     /**
@@ -235,8 +235,8 @@ public class ArrayUtils {
      * @param element the element to append
      * @return the modified array with the element appended
      */
-    public static short[] Append(short[] array, short element) {
-        return toPrimitiveArray(Append(toObjectArray(array), element));
+    public static short[] append(short[] array, short element) {
+        return toPrimitiveArray(append(toObjectArray(array), element));
     }
 
     /**
@@ -246,8 +246,8 @@ public class ArrayUtils {
      * @param element the element to append
      * @return the modified array with the element appended
      */
-    public static int[] Append(int[] array, int element) {
-        return toPrimitiveArray(Append(toObjectArray(array), element));
+    public static int[] append(int[] array, int element) {
+        return toPrimitiveArray(append(toObjectArray(array), element));
     }
 
     /**
@@ -257,8 +257,8 @@ public class ArrayUtils {
      * @param element the element to append
      * @return the modified array with the element appended
      */
-    public static long[] Append(long[] array, long element) {
-        return toPrimitiveArray(Append(toObjectArray(array), element));
+    public static long[] append(long[] array, long element) {
+        return toPrimitiveArray(append(toObjectArray(array), element));
     }
 
     /**
@@ -268,8 +268,8 @@ public class ArrayUtils {
      * @param element the element to append
      * @return the modified array with the element appended
      */
-    public static float[] Append(float[] array, float element) {
-        return toPrimitiveArray(Append(toObjectArray(array), element));
+    public static float[] append(float[] array, float element) {
+        return toPrimitiveArray(append(toObjectArray(array), element));
     }
 
     /**
@@ -279,8 +279,8 @@ public class ArrayUtils {
      * @param element the element to append
      * @return the modified array with the element appended
      */
-    public static double[] Append(double[] array, double element) {
-        return toPrimitiveArray(Append(toObjectArray(array), element));
+    public static double[] append(double[] array, double element) {
+        return toPrimitiveArray(append(toObjectArray(array), element));
     }
 
     /**
@@ -290,8 +290,8 @@ public class ArrayUtils {
      * @param element the element to append
      * @return the modified array with the element appended
      */
-    public static char[] Append(char[] array, char element) {
-        return toPrimitiveArray(Append(toObjectArray(array), element));
+    public static char[] append(char[] array, char element) {
+        return toPrimitiveArray(append(toObjectArray(array), element));
     }
 
     /**
@@ -301,8 +301,8 @@ public class ArrayUtils {
      * @param element the element to append
      * @return the modified array with the element appended
      */
-    public static boolean[] Append(boolean[] array, boolean element) {
-        return toPrimitiveArray(Append(toObjectArray(array), element));
+    public static boolean[] append(boolean[] array, boolean element) {
+        return toPrimitiveArray(append(toObjectArray(array), element));
     }
 
     /**
@@ -313,7 +313,7 @@ public class ArrayUtils {
      * @param <T>     the type of the array and element
      * @return the modified array with the element appended
      */
-    public static <T> T[] Append(T[] array, T element) {
+    public static <T> T[] append(T[] array, T element) {
         array = Arrays.copyOf(array, array.length + 1);
         array[array.length - 1] = element;
 
@@ -329,8 +329,8 @@ public class ArrayUtils {
      * @return the modified array with the element inserted
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static byte[] Insert(byte[] array, byte element, int index) {
-        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    public static byte[] insert(byte[] array, byte element, int index) {
+        return toPrimitiveArray(insert(toObjectArray(array), element, index));
     }
 
     /**
@@ -342,8 +342,8 @@ public class ArrayUtils {
      * @return the modified array with the element inserted
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static short[] Insert(short[] array, short element, int index) {
-        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    public static short[] insert(short[] array, short element, int index) {
+        return toPrimitiveArray(insert(toObjectArray(array), element, index));
     }
 
     /**
@@ -355,8 +355,8 @@ public class ArrayUtils {
      * @return the modified array with the element inserted
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static int[] Insert(int[] array, int element, int index) {
-        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    public static int[] insert(int[] array, int element, int index) {
+        return toPrimitiveArray(insert(toObjectArray(array), element, index));
     }
 
     /**
@@ -368,8 +368,8 @@ public class ArrayUtils {
      * @return the modified array with the element inserted
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static long[] Insert(long[] array, long element, int index) {
-        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    public static long[] insert(long[] array, long element, int index) {
+        return toPrimitiveArray(insert(toObjectArray(array), element, index));
     }
 
     /**
@@ -381,8 +381,8 @@ public class ArrayUtils {
      * @return the modified array with the element inserted
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static float[] Insert(float[] array, float element, int index) {
-        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    public static float[] insert(float[] array, float element, int index) {
+        return toPrimitiveArray(insert(toObjectArray(array), element, index));
     }
 
     /**
@@ -394,8 +394,8 @@ public class ArrayUtils {
      * @return the modified array with the element inserted
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static double[] Insert(double[] array, double element, int index) {
-        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    public static double[] insert(double[] array, double element, int index) {
+        return toPrimitiveArray(insert(toObjectArray(array), element, index));
     }
 
     /**
@@ -407,8 +407,8 @@ public class ArrayUtils {
      * @return the modified array with the element inserted
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static char[] Insert(char[] array, char element, int index) {
-        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    public static char[] insert(char[] array, char element, int index) {
+        return toPrimitiveArray(insert(toObjectArray(array), element, index));
     }
 
     /**
@@ -420,8 +420,8 @@ public class ArrayUtils {
      * @return the modified array with the element inserted
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static boolean[] Insert(boolean[] array, boolean element, int index) {
-        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    public static boolean[] insert(boolean[] array, boolean element, int index) {
+        return toPrimitiveArray(insert(toObjectArray(array), element, index));
     }
 
     /**
@@ -434,7 +434,7 @@ public class ArrayUtils {
      * @return the modified array with the element inserted
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static <T> T[] Insert(T[] array, T element, int index) {
+    public static <T> T[] insert(T[] array, T element, int index) {
         if (index < 0 || index > array.length)
             throw new IndexOutOfBoundsException();
 
@@ -454,8 +454,8 @@ public class ArrayUtils {
      * @return the modified array with the element removed
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static byte[] Remove(byte[] array, int index) {
-        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    public static byte[] remove(byte[] array, int index) {
+        return toPrimitiveArray(remove(toObjectArray(array), index));
     }
 
     /**
@@ -466,8 +466,8 @@ public class ArrayUtils {
      * @return the modified array with the element removed
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static short[] Remove(short[] array, int index) {
-        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    public static short[] remove(short[] array, int index) {
+        return toPrimitiveArray(remove(toObjectArray(array), index));
     }
 
     /**
@@ -478,8 +478,8 @@ public class ArrayUtils {
      * @return the modified array with the element removed
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static int[] Remove(int[] array, int index) {
-        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    public static int[] remove(int[] array, int index) {
+        return toPrimitiveArray(remove(toObjectArray(array), index));
     }
 
     /**
@@ -490,8 +490,8 @@ public class ArrayUtils {
      * @return the modified array with the element removed
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static long[] Remove(long[] array, int index) {
-        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    public static long[] remove(long[] array, int index) {
+        return toPrimitiveArray(remove(toObjectArray(array), index));
     }
 
     /**
@@ -502,8 +502,8 @@ public class ArrayUtils {
      * @return the modified array with the element removed
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static float[] Remove(float[] array, int index) {
-        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    public static float[] remove(float[] array, int index) {
+        return toPrimitiveArray(remove(toObjectArray(array), index));
     }
 
     /**
@@ -514,8 +514,8 @@ public class ArrayUtils {
      * @return the modified array with the element removed
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static double[] Remove(double[] array, int index) {
-        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    public static double[] remove(double[] array, int index) {
+        return toPrimitiveArray(remove(toObjectArray(array), index));
     }
 
     /**
@@ -526,8 +526,8 @@ public class ArrayUtils {
      * @return the modified array with the element removed
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static char[] Remove(char[] array, int index) {
-        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    public static char[] remove(char[] array, int index) {
+        return toPrimitiveArray(remove(toObjectArray(array), index));
     }
 
     /**
@@ -538,8 +538,8 @@ public class ArrayUtils {
      * @return the modified array with the element removed
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static boolean[] Remove(boolean[] array, int index) {
-        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    public static boolean[] remove(boolean[] array, int index) {
+        return toPrimitiveArray(remove(toObjectArray(array), index));
     }
 
     /**
@@ -551,7 +551,7 @@ public class ArrayUtils {
      * @return the modified array with the element removed
      * @throws IndexOutOfBoundsException if the index is out of range
      */
-    public static <T> T[] Remove(T[] array, int index) {
+    public static <T> T[] remove(T[] array, int index) {
         if (index < 0 || index >= array.length)
             throw new IndexOutOfBoundsException();
 
@@ -570,8 +570,8 @@ public class ArrayUtils {
      * @param array2 the second array
      * @return the concatenated array
      */
-    public static byte[] Concatenate(byte[] array1, byte[] array2) {
-        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    public static byte[] concatenate(byte[] array1, byte[] array2) {
+        return toPrimitiveArray(concatenate(toObjectArray(array1), toObjectArray(array2)));
     }
 
     /**
@@ -581,8 +581,8 @@ public class ArrayUtils {
      * @param array2 the second array
      * @return the concatenated array
      */
-    public static short[] Concatenate(short[] array1, short[] array2) {
-        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    public static short[] concatenate(short[] array1, short[] array2) {
+        return toPrimitiveArray(concatenate(toObjectArray(array1), toObjectArray(array2)));
     }
 
     /**
@@ -592,8 +592,8 @@ public class ArrayUtils {
      * @param array2 the second array
      * @return the concatenated array
      */
-    public static int[] Concatenate(int[] array1, int[] array2) {
-        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    public static int[] concatenate(int[] array1, int[] array2) {
+        return toPrimitiveArray(concatenate(toObjectArray(array1), toObjectArray(array2)));
     }
 
     /**
@@ -603,8 +603,8 @@ public class ArrayUtils {
      * @param array2 the second array
      * @return the concatenated array
      */
-    public static long[] Concatenate(long[] array1, long[] array2) {
-        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    public static long[] concatenate(long[] array1, long[] array2) {
+        return toPrimitiveArray(concatenate(toObjectArray(array1), toObjectArray(array2)));
     }
 
     /**
@@ -614,8 +614,8 @@ public class ArrayUtils {
      * @param array2 the second array
      * @return the concatenated array
      */
-    public static float[] Concatenate(float[] array1, float[] array2) {
-        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    public static float[] concatenate(float[] array1, float[] array2) {
+        return toPrimitiveArray(concatenate(toObjectArray(array1), toObjectArray(array2)));
     }
 
     /**
@@ -625,8 +625,8 @@ public class ArrayUtils {
      * @param array2 the second array
      * @return the concatenated array
      */
-    public static double[] Concatenate(double[] array1, double[] array2) {
-        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    public static double[] concatenate(double[] array1, double[] array2) {
+        return toPrimitiveArray(concatenate(toObjectArray(array1), toObjectArray(array2)));
     }
 
     /**
@@ -636,8 +636,8 @@ public class ArrayUtils {
      * @param array2 the second array
      * @return the concatenated array
      */
-    public static char[] Concatenate(char[] array1, char[] array2) {
-        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    public static char[] concatenate(char[] array1, char[] array2) {
+        return toPrimitiveArray(concatenate(toObjectArray(array1), toObjectArray(array2)));
     }
 
     /**
@@ -647,8 +647,8 @@ public class ArrayUtils {
      * @param array2 the second array
      * @return the concatenated array
      */
-    public static boolean[] Concatenate(boolean[] array1, boolean[] array2) {
-        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    public static boolean[] concatenate(boolean[] array1, boolean[] array2) {
+        return toPrimitiveArray(concatenate(toObjectArray(array1), toObjectArray(array2)));
     }
 
     /**
@@ -659,12 +659,44 @@ public class ArrayUtils {
      * @param <T>    the type of the arrays
      * @return the concatenated array
      */
-    public static <T> T[] Concatenate(T[] array1, T[] array2) {
+    public static <T> T[] concatenate(T[] array1, T[] array2) {
         T[] concatenated = Arrays.copyOf(array1, array1.length + array2.length);
 
         System.arraycopy(array2, 0, concatenated, array1.length, array2.length);
 
         return concatenated;
+    }
+
+    public static byte[] reverse(byte[] array) {
+        return toPrimitiveArray(reverse(toObjectArray(array)));
+    }
+
+    public static short[] reverse(short[] array) {
+        return toPrimitiveArray(reverse(toObjectArray(array)));
+    }
+
+    public static int[] reverse(int[] array) {
+        return toPrimitiveArray(reverse(toObjectArray(array)));
+    }
+
+    public static long[] reverse(long[] array) {
+        return toPrimitiveArray(reverse(toObjectArray(array)));
+    }
+
+    public static float[] reverse(float[] array) {
+        return toPrimitiveArray(reverse(toObjectArray(array)));
+    }
+
+    public static double[] reverse(double[] array) {
+        return toPrimitiveArray(reverse(toObjectArray(array)));
+    }
+
+    public static char[] reverse(char[] array) {
+        return toPrimitiveArray(reverse(toObjectArray(array)));
+    }
+
+    public static boolean[] reverse(boolean[] array) {
+        return toPrimitiveArray(reverse(toObjectArray(array)));
     }
 
     /**
@@ -674,7 +706,7 @@ public class ArrayUtils {
      * @param <T>   the type of the array
      * @return the reversed array
      */
-    public static <T> T[] Reverse(T[] array) {
+    public static <T> T[] reverse(T[] array) {
         T[] reversed = Arrays.copyOf(array, array.length);
 
         for (int i = 0; i < reversed.length / 2; i++) {

--- a/src/main/java/de/tinf/collections/ArrayUtils.java
+++ b/src/main/java/de/tinf/collections/ArrayUtils.java
@@ -8,6 +8,304 @@ import java.util.Arrays;
 public class ArrayUtils {
 
     /**
+     * Converts an array of objects to an array of primitive values.
+     *
+     * @param array the array of objects to be converted
+     * @return an array of primitive values corresponding to the input array
+     */
+    public static byte[] toPrimitiveArray(Byte[] array) {
+        byte[] casted = new byte[array.length];
+        for (int i = 0; i < casted.length; i++) {
+            casted[i] = array[i];
+        }
+
+        return casted;
+    }
+
+    /**
+     * Converts an array of objects to an array of primitive values.
+     *
+     * @param array the array of objects to be converted
+     * @return an array of primitive values corresponding to the input array
+     */
+    public static short[] toPrimitiveArray(Short[] array) {
+        short[] casted = new short[array.length];
+        for (int i = 0; i < casted.length; i++) {
+            casted[i] = array[i];
+        }
+
+        return casted;
+    }
+
+    /**
+     * Converts an array of objects to an array of primitive values.
+     *
+     * @param array the array of objects to be converted
+     * @return an array of primitive values corresponding to the input array
+     */
+    public static int[] toPrimitiveArray(Integer[] array) {
+        return Arrays.stream(array).mapToInt(Integer::intValue).toArray();
+    }
+
+    /**
+     * Converts an array of objects to an array of primitive values.
+     *
+     * @param array the array of objects to be converted
+     * @return an array of primitive values corresponding to the input array
+     */
+    public static long[] toPrimitiveArray(Long[] array) {
+        return Arrays.stream(array).mapToLong(Long::longValue).toArray();
+    }
+
+    /**
+     * Converts an array of objects to an array of primitive values.
+     *
+     * @param array the array of objects to be converted
+     * @return an array of primitive values corresponding to the input array
+     */
+    public static float[] toPrimitiveArray(Float[] array) {
+        float[] casted = new float[array.length];
+        for (int i = 0; i < casted.length; i++) {
+            casted[i] = array[i];
+        }
+
+        return casted;
+    }
+
+    /**
+     * Converts an array of objects to an array of primitive values.
+     *
+     * @param array the array of objects to be converted
+     * @return an array of primitive values corresponding to the input array
+     */
+    public static double[] toPrimitiveArray(Double[] array) {
+        return Arrays.stream(array).mapToDouble(Double::doubleValue).toArray();
+    }
+
+    /**
+     * Converts an array of objects to an array of primitive values.
+     *
+     * @param array the array of objects to be converted
+     * @return an array of primitive values corresponding to the input array
+     */
+    public static char[] toPrimitiveArray(Character[] array) {
+        char[] casted = new char[array.length];
+        for (int i = 0; i < casted.length; i++) {
+            casted[i] = array[i];
+        }
+
+        return casted;
+    }
+
+    /**
+     * Converts an array of objects to an array of primitive values.
+     *
+     * @param array the array of objects to be converted
+     * @return an array of primitive values corresponding to the input array
+     */
+    public static boolean[] toPrimitiveArray(Boolean[] array) {
+        boolean[] casted = new boolean[array.length];
+        for (int i = 0; i < casted.length; i++) {
+            casted[i] = array[i];
+        }
+
+        return casted;
+    }
+
+    /**
+     * Converts a primitive type array to an array of objects.
+     *
+     * @param array the primitive type array to be converted
+     * @return an array of objects corresponding to the input array
+     */
+    public static Byte[] toObjectArray(byte[] array) {
+        Byte[] casted = new Byte[array.length];
+        for (int i = 0; i < casted.length; i++) {
+            casted[i] = array[i];
+        }
+
+        return casted;
+    }
+
+    /**
+     * Converts a primitive type array to an array of objects.
+     *
+     * @param array the primitive type array to be converted
+     * @return an array of objects corresponding to the input array
+     */
+    public static Short[] toObjectArray(short[] array) {
+        Short[] casted = new Short[array.length];
+        for (int i = 0; i < casted.length; i++) {
+            casted[i] = array[i];
+        }
+
+        return casted;
+    }
+
+    /**
+     * Converts a primitive type array to an array of objects.
+     *
+     * @param array the primitive type array to be converted
+     * @return an array of objects corresponding to the input array
+     */
+    public static Integer[] toObjectArray(int[] array) {
+        return Arrays.stream(array).boxed().toArray(Integer[]::new);
+    }
+
+    /**
+     * Converts a primitive type array to an array of objects.
+     *
+     * @param array the primitive type array to be converted
+     * @return an array of objects corresponding to the input array
+     */
+    public static Long[] toObjectArray(long[] array) {
+        return Arrays.stream(array).boxed().toArray(Long[]::new);
+    }
+
+    /**
+     * Converts a primitive type array to an array of objects.
+     *
+     * @param array the primitive type array to be converted
+     * @return an array of objects corresponding to the input array
+     */
+    public static Float[] toObjectArray(float[] array) {
+        Float[] casted = new Float[array.length];
+        for (int i = 0; i < casted.length; i++) {
+            casted[i] = array[i];
+        }
+
+        return casted;
+    }
+
+    /**
+     * Converts a primitive type array to an array of objects.
+     *
+     * @param array the primitive type array to be converted
+     * @return an array of objects corresponding to the input array
+     */
+    public static Double[] toObjectArray(double[] array) {
+        return Arrays.stream(array).boxed().toArray(Double[]::new);
+    }
+
+    /**
+     * Converts a primitive type array to an array of objects.
+     *
+     * @param array the primitive type array to be converted
+     * @return an array of objects corresponding to the input array
+     */
+    public static Character[] toObjectArray(char[] array) {
+        Character[] casted = new Character[array.length];
+        for (int i = 0; i < casted.length; i++) {
+            casted[i] = array[i];
+        }
+
+        return casted;
+    }
+
+    /**
+     * Converts a primitive type array to an array of objects.
+     *
+     * @param array the primitive type array to be converted
+     * @return an array of objects corresponding to the input array
+     */
+    public static Boolean[] toObjectArray(boolean[] array) {
+        Boolean[] casted = new Boolean[array.length];
+        for (int i = 0; i < casted.length; i++) {
+            casted[i] = array[i];
+        }
+
+        return casted;
+    }
+
+    /**
+     * Appends an element to the end of the array.
+     *
+     * @param array   the array to append the element to
+     * @param element the element to append
+     * @return the modified array with the element appended
+     */
+    public static byte[] Append(byte[] array, byte element) {
+        return toPrimitiveArray(Append(toObjectArray(array), element));
+    }
+
+    /**
+     * Appends an element to the end of the array.
+     *
+     * @param array   the array to append the element to
+     * @param element the element to append
+     * @return the modified array with the element appended
+     */
+    public static short[] Append(short[] array, short element) {
+        return toPrimitiveArray(Append(toObjectArray(array), element));
+    }
+
+    /**
+     * Appends an element to the end of the array.
+     *
+     * @param array   the array to append the element to
+     * @param element the element to append
+     * @return the modified array with the element appended
+     */
+    public static int[] Append(int[] array, int element) {
+        return toPrimitiveArray(Append(toObjectArray(array), element));
+    }
+
+    /**
+     * Appends an element to the end of the array.
+     *
+     * @param array   the array to append the element to
+     * @param element the element to append
+     * @return the modified array with the element appended
+     */
+    public static long[] Append(long[] array, long element) {
+        return toPrimitiveArray(Append(toObjectArray(array), element));
+    }
+
+    /**
+     * Appends an element to the end of the array.
+     *
+     * @param array   the array to append the element to
+     * @param element the element to append
+     * @return the modified array with the element appended
+     */
+    public static float[] Append(float[] array, float element) {
+        return toPrimitiveArray(Append(toObjectArray(array), element));
+    }
+
+    /**
+     * Appends an element to the end of the array.
+     *
+     * @param array   the array to append the element to
+     * @param element the element to append
+     * @return the modified array with the element appended
+     */
+    public static double[] Append(double[] array, double element) {
+        return toPrimitiveArray(Append(toObjectArray(array), element));
+    }
+
+    /**
+     * Appends an element to the end of the array.
+     *
+     * @param array   the array to append the element to
+     * @param element the element to append
+     * @return the modified array with the element appended
+     */
+    public static char[] Append(char[] array, char element) {
+        return toPrimitiveArray(Append(toObjectArray(array), element));
+    }
+
+    /**
+     * Appends an element to the end of the array.
+     *
+     * @param array   the array to append the element to
+     * @param element the element to append
+     * @return the modified array with the element appended
+     */
+    public static boolean[] Append(boolean[] array, boolean element) {
+        return toPrimitiveArray(Append(toObjectArray(array), element));
+    }
+
+    /**
      * Appends an element to the end of the array.
      *
      * @param array   the array to append the element to
@@ -28,12 +326,117 @@ public class ArrayUtils {
      * @param array   the array to insert the element into
      * @param element the element to insert
      * @param index   the index at which to insert the element
+     * @return the modified array with the element inserted
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static byte[] Insert(byte[] array, byte element, int index) {
+        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    }
+
+    /**
+     * Inserts an element at the specified index in the array.
+     *
+     * @param array   the array to insert the element into
+     * @param element the element to insert
+     * @param index   the index at which to insert the element
+     * @return the modified array with the element inserted
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static short[] Insert(short[] array, short element, int index) {
+        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    }
+
+    /**
+     * Inserts an element at the specified index in the array.
+     *
+     * @param array   the array to insert the element into
+     * @param element the element to insert
+     * @param index   the index at which to insert the element
+     * @return the modified array with the element inserted
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static int[] Insert(int[] array, int element, int index) {
+        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    }
+
+    /**
+     * Inserts an element at the specified index in the array.
+     *
+     * @param array   the array to insert the element into
+     * @param element the element to insert
+     * @param index   the index at which to insert the element
+     * @return the modified array with the element inserted
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static long[] Insert(long[] array, long element, int index) {
+        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    }
+
+    /**
+     * Inserts an element at the specified index in the array.
+     *
+     * @param array   the array to insert the element into
+     * @param element the element to insert
+     * @param index   the index at which to insert the element
+     * @return the modified array with the element inserted
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static float[] Insert(float[] array, float element, int index) {
+        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    }
+
+    /**
+     * Inserts an element at the specified index in the array.
+     *
+     * @param array   the array to insert the element into
+     * @param element the element to insert
+     * @param index   the index at which to insert the element
+     * @return the modified array with the element inserted
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static double[] Insert(double[] array, double element, int index) {
+        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    }
+
+    /**
+     * Inserts an element at the specified index in the array.
+     *
+     * @param array   the array to insert the element into
+     * @param element the element to insert
+     * @param index   the index at which to insert the element
+     * @return the modified array with the element inserted
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static char[] Insert(char[] array, char element, int index) {
+        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    }
+
+    /**
+     * Inserts an element at the specified index in the array.
+     *
+     * @param array   the array to insert the element into
+     * @param element the element to insert
+     * @param index   the index at which to insert the element
+     * @return the modified array with the element inserted
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static boolean[] Insert(boolean[] array, boolean element, int index) {
+        return toPrimitiveArray(Insert(toObjectArray(array), element, index));
+    }
+
+    /**
+     * Inserts an element at the specified index in the array.
+     *
+     * @param array   the array to insert the element into
+     * @param element the element to insert
+     * @param index   the index at which to insert the element
      * @param <T>     the type of the array and element
      * @return the modified array with the element inserted
      * @throws IndexOutOfBoundsException if the index is out of range
      */
     public static <T> T[] Insert(T[] array, T element, int index) {
-        if (index < 0 || index > array.length) throw new IndexOutOfBoundsException();
+        if (index < 0 || index > array.length)
+            throw new IndexOutOfBoundsException();
 
         T[] modified = Arrays.copyOf(array, array.length + 1);
         modified[index] = element;
@@ -48,12 +451,109 @@ public class ArrayUtils {
      *
      * @param array the array to remove the element from
      * @param index the index of the element to remove
+     * @return the modified array with the element removed
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static byte[] Remove(byte[] array, int index) {
+        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    }
+
+    /**
+     * Removes an element at the specified index from the array.
+     *
+     * @param array the array to remove the element from
+     * @param index the index of the element to remove
+     * @return the modified array with the element removed
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static short[] Remove(short[] array, int index) {
+        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    }
+
+    /**
+     * Removes an element at the specified index from the array.
+     *
+     * @param array the array to remove the element from
+     * @param index the index of the element to remove
+     * @return the modified array with the element removed
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static int[] Remove(int[] array, int index) {
+        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    }
+
+    /**
+     * Removes an element at the specified index from the array.
+     *
+     * @param array the array to remove the element from
+     * @param index the index of the element to remove
+     * @return the modified array with the element removed
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static long[] Remove(long[] array, int index) {
+        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    }
+
+    /**
+     * Removes an element at the specified index from the array.
+     *
+     * @param array the array to remove the element from
+     * @param index the index of the element to remove
+     * @return the modified array with the element removed
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static float[] Remove(float[] array, int index) {
+        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    }
+
+    /**
+     * Removes an element at the specified index from the array.
+     *
+     * @param array the array to remove the element from
+     * @param index the index of the element to remove
+     * @return the modified array with the element removed
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static double[] Remove(double[] array, int index) {
+        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    }
+
+    /**
+     * Removes an element at the specified index from the array.
+     *
+     * @param array the array to remove the element from
+     * @param index the index of the element to remove
+     * @return the modified array with the element removed
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static char[] Remove(char[] array, int index) {
+        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    }
+
+    /**
+     * Removes an element at the specified index from the array.
+     *
+     * @param array the array to remove the element from
+     * @param index the index of the element to remove
+     * @return the modified array with the element removed
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    public static boolean[] Remove(boolean[] array, int index) {
+        return toPrimitiveArray(Remove(toObjectArray(array), index));
+    }
+
+    /**
+     * Removes an element at the specified index from the array.
+     *
+     * @param array the array to remove the element from
+     * @param index the index of the element to remove
      * @param <T>   the type of the array
      * @return the modified array with the element removed
      * @throws IndexOutOfBoundsException if the index is out of range
      */
     public static <T> T[] Remove(T[] array, int index) {
-        if (index < 0 || index >= array.length) throw new IndexOutOfBoundsException();
+        if (index < 0 || index >= array.length)
+            throw new IndexOutOfBoundsException();
 
         T[] modified = Arrays.copyOf(array, array.length - 1);
 
@@ -61,6 +561,94 @@ public class ArrayUtils {
         System.arraycopy(array, index + 1, modified, index, array.length - index - 1);
 
         return modified;
+    }
+
+    /**
+     * Concatenates two arrays into a single array.
+     *
+     * @param array1 the first array
+     * @param array2 the second array
+     * @return the concatenated array
+     */
+    public static byte[] Concatenate(byte[] array1, byte[] array2) {
+        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    }
+
+    /**
+     * Concatenates two arrays into a single array.
+     *
+     * @param array1 the first array
+     * @param array2 the second array
+     * @return the concatenated array
+     */
+    public static short[] Concatenate(short[] array1, short[] array2) {
+        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    }
+
+    /**
+     * Concatenates two arrays into a single array.
+     *
+     * @param array1 the first array
+     * @param array2 the second array
+     * @return the concatenated array
+     */
+    public static int[] Concatenate(int[] array1, int[] array2) {
+        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    }
+
+    /**
+     * Concatenates two arrays into a single array.
+     *
+     * @param array1 the first array
+     * @param array2 the second array
+     * @return the concatenated array
+     */
+    public static long[] Concatenate(long[] array1, long[] array2) {
+        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    }
+
+    /**
+     * Concatenates two arrays into a single array.
+     *
+     * @param array1 the first array
+     * @param array2 the second array
+     * @return the concatenated array
+     */
+    public static float[] Concatenate(float[] array1, float[] array2) {
+        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    }
+
+    /**
+     * Concatenates two arrays into a single array.
+     *
+     * @param array1 the first array
+     * @param array2 the second array
+     * @return the concatenated array
+     */
+    public static double[] Concatenate(double[] array1, double[] array2) {
+        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    }
+
+    /**
+     * Concatenates two arrays into a single array.
+     *
+     * @param array1 the first array
+     * @param array2 the second array
+     * @return the concatenated array
+     */
+    public static char[] Concatenate(char[] array1, char[] array2) {
+        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
+    }
+
+    /**
+     * Concatenates two arrays into a single array.
+     *
+     * @param array1 the first array
+     * @param array2 the second array
+     * @return the concatenated array
+     */
+    public static boolean[] Concatenate(boolean[] array1, boolean[] array2) {
+        return toPrimitiveArray(Concatenate(toObjectArray(array1), toObjectArray(array2)));
     }
 
     /**

--- a/src/main/java/de/tinf/collections/ArrayUtils.java
+++ b/src/main/java/de/tinf/collections/ArrayUtils.java
@@ -8,10 +8,11 @@ import java.util.Arrays;
 public class ArrayUtils {
 
     /**
-     * Converts an array of objects to an array of primitive values.
+     * Converts an array of {@link Byte} objects to an array of primitive
+     * {@code byte}s.
      *
-     * @param array the array of objects to be converted
-     * @return an array of primitive values corresponding to the input array
+     * @param array the array of {@link Byte} objects to be converted
+     * @return an array of primitive {@code byte}s corresponding to the input array
      */
     public static byte[] toPrimitiveArray(Byte[] array) {
         byte[] casted = new byte[array.length];
@@ -23,10 +24,12 @@ public class ArrayUtils {
     }
 
     /**
-     * Converts an array of objects to an array of primitive values.
+     * Converts an array of {@link Short} objects to an array of primitive
+     * {@code short} values.
      *
-     * @param array the array of objects to be converted
-     * @return an array of primitive values corresponding to the input array
+     * @param array the array of {@link Short} objects to be converted
+     * @return an array of primitive {@code short} values corresponding to the input
+     *         array
      */
     public static short[] toPrimitiveArray(Short[] array) {
         short[] casted = new short[array.length];
@@ -38,30 +41,35 @@ public class ArrayUtils {
     }
 
     /**
-     * Converts an array of objects to an array of primitive values.
+     * Converts an array of {@link Integer} objects to an array of primitive
+     * {@code int}s.
      *
-     * @param array the array of objects to be converted
-     * @return an array of primitive values corresponding to the input array
+     * @param array the array of {@link Integer} objects to be converted
+     * @return an array of primitive {@code int}s corresponding to the input array
      */
     public static int[] toPrimitiveArray(Integer[] array) {
         return Arrays.stream(array).mapToInt(Integer::intValue).toArray();
     }
 
     /**
-     * Converts an array of objects to an array of primitive values.
+     * Converts an array of {@link Long} objects to an array of primitive
+     * {@code long} values.
      *
-     * @param array the array of objects to be converted
-     * @return an array of primitive values corresponding to the input array
+     * @param array the array of {@link Long} objects to be converted
+     * @return an array of primitive {@code long} values corresponding to the input
+     *         array
      */
     public static long[] toPrimitiveArray(Long[] array) {
         return Arrays.stream(array).mapToLong(Long::longValue).toArray();
     }
 
     /**
-     * Converts an array of objects to an array of primitive values.
+     * Converts an array of {@link Float} objects to an array of primitive
+     * {@code float} values.
      *
-     * @param array the array of objects to be converted
-     * @return an array of primitive values corresponding to the input array
+     * @param array the array of {@link Float} objects to be converted
+     * @return an array of primitive {@code float} values corresponding to the input
+     *         array
      */
     public static float[] toPrimitiveArray(Float[] array) {
         float[] casted = new float[array.length];
@@ -73,20 +81,24 @@ public class ArrayUtils {
     }
 
     /**
-     * Converts an array of objects to an array of primitive values.
+     * Converts an array of {@link Double} objects to an array of primitive
+     * {@code double} values.
      *
-     * @param array the array of objects to be converted
-     * @return an array of primitive values corresponding to the input array
+     * @param array the array of {@link Double} objects to be converted
+     * @return an array of primitive {@code double} values corresponding to the
+     *         input array
      */
     public static double[] toPrimitiveArray(Double[] array) {
         return Arrays.stream(array).mapToDouble(Double::doubleValue).toArray();
     }
 
     /**
-     * Converts an array of objects to an array of primitive values.
+     * Converts an array of {@link Character} objects to an array of primitive
+     * {@code char} values.
      *
-     * @param array the array of objects to be converted
-     * @return an array of primitive values corresponding to the input array
+     * @param array the array of {@link Character} objects to be converted
+     * @return an array of primitive {@code char} values corresponding to the input
+     *         array
      */
     public static char[] toPrimitiveArray(Character[] array) {
         char[] casted = new char[array.length];
@@ -98,10 +110,12 @@ public class ArrayUtils {
     }
 
     /**
-     * Converts an array of objects to an array of primitive values.
+     * Converts an array of {@link Boolean} objects to an array of primitive
+     * {@code boolean} values.
      *
-     * @param array the array of objects to be converted
-     * @return an array of primitive values corresponding to the input array
+     * @param array the array of {@link Boolean} objects to be converted
+     * @return an array of primitive {@code boolean} values corresponding to the
+     *         input array
      */
     public static boolean[] toPrimitiveArray(Boolean[] array) {
         boolean[] casted = new boolean[array.length];
@@ -113,10 +127,11 @@ public class ArrayUtils {
     }
 
     /**
-     * Converts a primitive type array to an array of objects.
-     *
-     * @param array the primitive type array to be converted
-     * @return an array of objects corresponding to the input array
+     * Converts an array of primitive {@code byte}s to an array of {@link Byte}
+     * objects.
+     * 
+     * @param array the array of {@code byte}s to be converted
+     * @return an array of {@link Byte} objects
      */
     public static Byte[] toObjectArray(byte[] array) {
         Byte[] casted = new Byte[array.length];
@@ -128,10 +143,11 @@ public class ArrayUtils {
     }
 
     /**
-     * Converts a primitive type array to an array of objects.
-     *
-     * @param array the primitive type array to be converted
-     * @return an array of objects corresponding to the input array
+     * Converts an array of primitive {@code short} values to an array of
+     * {@link Short} objects.
+     * 
+     * @param array the array of {@code short} values to be converted
+     * @return an array of {@link Short} objects
      */
     public static Short[] toObjectArray(short[] array) {
         Short[] casted = new Short[array.length];
@@ -143,30 +159,33 @@ public class ArrayUtils {
     }
 
     /**
-     * Converts a primitive type array to an array of objects.
-     *
-     * @param array the primitive type array to be converted
-     * @return an array of objects corresponding to the input array
+     * Converts an array of primitive {@code int}s to an array of {@link Integer}
+     * objects.
+     * 
+     * @param array the array of {@code int}s to be converted
+     * @return an array of {@link Integer} objects
      */
     public static Integer[] toObjectArray(int[] array) {
         return Arrays.stream(array).boxed().toArray(Integer[]::new);
     }
 
     /**
-     * Converts a primitive type array to an array of objects.
-     *
-     * @param array the primitive type array to be converted
-     * @return an array of objects corresponding to the input array
+     * Converts an array of primitive {@code long} values to an array of
+     * {@link Long} objects.
+     * 
+     * @param array the array of {@code long} values to be converted
+     * @return an array of {@link Long} objects
      */
     public static Long[] toObjectArray(long[] array) {
         return Arrays.stream(array).boxed().toArray(Long[]::new);
     }
 
     /**
-     * Converts a primitive type array to an array of objects.
-     *
-     * @param array the primitive type array to be converted
-     * @return an array of objects corresponding to the input array
+     * Converts an array of primitive {@code float}s to an array of {@link Float}
+     * objects.
+     * 
+     * @param array the array of {@code float}s to be converted
+     * @return an array of {@link Float} objects
      */
     public static Float[] toObjectArray(float[] array) {
         Float[] casted = new Float[array.length];
@@ -178,20 +197,22 @@ public class ArrayUtils {
     }
 
     /**
-     * Converts a primitive type array to an array of objects.
-     *
-     * @param array the primitive type array to be converted
-     * @return an array of objects corresponding to the input array
+     * Converts an array of primitive {@code double}s to an array of {@link Double}
+     * objects.
+     * 
+     * @param array the array of {@code double}s to be converted
+     * @return an array of {@link Double} objects
      */
     public static Double[] toObjectArray(double[] array) {
         return Arrays.stream(array).boxed().toArray(Double[]::new);
     }
 
     /**
-     * Converts a primitive type array to an array of objects.
-     *
-     * @param array the primitive type array to be converted
-     * @return an array of objects corresponding to the input array
+     * Converts an array of primitive {@code char}s to an array of {@link Character}
+     * objects.
+     * 
+     * @param array the array of {@code char}s to be converted
+     * @return an array of {@link Character} objects
      */
     public static Character[] toObjectArray(char[] array) {
         Character[] casted = new Character[array.length];
@@ -203,10 +224,11 @@ public class ArrayUtils {
     }
 
     /**
-     * Converts a primitive type array to an array of objects.
-     *
-     * @param array the primitive type array to be converted
-     * @return an array of objects corresponding to the input array
+     * Converts an array of primitive {@code boolean}s to an array of
+     * {@link Boolean} objects.
+     * 
+     * @param array the array of {@code boolean}s to be converted
+     * @return an array of {@link Boolean} objects
      */
     public static Boolean[] toObjectArray(boolean[] array) {
         Boolean[] casted = new Boolean[array.length];

--- a/src/test/java/de/tinf/collections/ArrayUtilsTest.java
+++ b/src/test/java/de/tinf/collections/ArrayUtilsTest.java
@@ -55,4 +55,212 @@ public class ArrayUtilsTest {
         Integer[] result = ArrayUtils.Reverse(array);
         assertArrayEquals(expected, result);
     }
+
+    @Test
+    void testToPrimitiveArrayByte() {
+        Byte[] array = { 1, 2, 3 };
+        byte[] expected = { 1, 2, 3 };
+        byte[] result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new Byte[0];
+        expected = new byte[0];
+        result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToPrimitiveArrayShort() {
+        Short[] array = { 1, 2, 3 };
+        short[] expected = { 1, 2, 3 };
+        short[] result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new Short[0];
+        expected = new short[0];
+        result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToPrimitiveArrayInteger() {
+        Integer[] array = { 1, 2, 3 };
+        int[] expected = { 1, 2, 3 };
+        int[] result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new Integer[0];
+        expected = new int[0];
+        result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToPrimitiveArrayLong() {
+        Long[] array = { 1L, 2L, 3L };
+        long[] expected = { 1L, 2L, 3L };
+        long[] result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new Long[0];
+        expected = new long[0];
+        result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToPrimitiveArrayFloat() {
+        Float[] array = { 1.1f, 2.2f, 3.3f };
+        float[] expected = { 1.1f, 2.2f, 3.3f };
+        float[] result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result, 0.0001f);
+
+        array = new Float[0];
+        expected = new float[0];
+        result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToPrimitiveArrayDouble() {
+        Double[] array = { 1.1, 2.2, 3.3 };
+        double[] expected = { 1.1, 2.2, 3.3 };
+        double[] result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result, 0.0001);
+
+        array = new Double[0];
+        expected = new double[0];
+        result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToPrimitiveArrayCharacter() {
+        Character[] array = { 'a', 'b', 'c' };
+        char[] expected = { 'a', 'b', 'c' };
+        char[] result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new Character[0];
+        expected = new char[0];
+        result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToPrimitiveArrayBoolean() {
+        Boolean[] array = { true, false, true };
+        boolean[] expected = { true, false, true };
+        boolean[] result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new Boolean[0];
+        expected = new boolean[0];
+        result = ArrayUtils.toPrimitiveArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToObjectArrayByte() {
+        byte[] array = { 1, 2, 3 };
+        Byte[] expected = { 1, 2, 3 };
+        Byte[] result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new byte[0];
+        expected = new Byte[0];
+        result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToObjectArrayShort() {
+        short[] array = { 1, 2, 3 };
+        Short[] expected = { 1, 2, 3 };
+        Short[] result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new short[0];
+        expected = new Short[0];
+        result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToObjectArrayInteger() {
+        int[] array = { 1, 2, 3 };
+        Integer[] expected = { 1, 2, 3 };
+        Integer[] result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new int[0];
+        expected = new Integer[0];
+        result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToObjectArrayLong() {
+        long[] array = { 1L, 2L, 3L };
+        Long[] expected = { 1L, 2L, 3L };
+        Long[] result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new long[0];
+        expected = new Long[0];
+        result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToObjectArrayFloat() {
+        float[] array = { 1.1f, 2.2f, 3.3f };
+        Float[] expected = { 1.1f, 2.2f, 3.3f };
+        Float[] result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new float[0];
+        expected = new Float[0];
+        result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToObjectArrayDouble() {
+        double[] array = { 1.1, 2.2, 3.3 };
+        Double[] expected = { 1.1, 2.2, 3.3 };
+        Double[] result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new double[0];
+        expected = new Double[0];
+        result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToObjectArrayCharacter() {
+        char[] array = { 'a', 'b', 'c' };
+        Character[] expected = { 'a', 'b', 'c' };
+        Character[] result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new char[0];
+        expected = new Character[0];
+        result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void testToObjectArrayBoolean() {
+        boolean[] array = { true, false, true };
+        Boolean[] expected = { true, false, true };
+        Boolean[] result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+
+        array = new boolean[0];
+        expected = new Boolean[0];
+        result = ArrayUtils.toObjectArray(array);
+        assertArrayEquals(expected, result);
+    }
 }

--- a/src/test/java/de/tinf/collections/ArrayUtilsTest.java
+++ b/src/test/java/de/tinf/collections/ArrayUtilsTest.java
@@ -10,7 +10,7 @@ public class ArrayUtilsTest {
     void testAppend() {
         Integer[] array = { 1, 2, 3 };
         Integer[] expected = { 1, 2, 3, 4 };
-        Integer[] result = ArrayUtils.Append(array, 4);
+        Integer[] result = ArrayUtils.append(array, 4);
         assertArrayEquals(expected, result);
     }
 
@@ -18,20 +18,22 @@ public class ArrayUtilsTest {
     void testInsert() {
         Integer[] array = { 1, 2, 3 };
         Integer[] expected = { 1, 2, 4, 3 };
-        Integer[] result = ArrayUtils.Insert(array, 4, 2);
+        Integer[] result = ArrayUtils.insert(array, 4, 2);
         assertArrayEquals(expected, result);
 
-        assertThrowsExactly(IndexOutOfBoundsException.class, () -> ArrayUtils.Insert(array, 4, 4), "Should throw an IndexOutOfBoundsException.");
+        assertThrowsExactly(IndexOutOfBoundsException.class, () -> ArrayUtils.insert(array, 4, 4),
+                "Should throw an IndexOutOfBoundsException.");
     }
 
     @Test
     void testRemove() {
         Integer[] array = { 1, 2, 3 };
         Integer[] expected = { 1, 3 };
-        Integer[] result = ArrayUtils.Remove(array, 1);
+        Integer[] result = ArrayUtils.remove(array, 1);
         assertArrayEquals(expected, result);
 
-        assertThrowsExactly(IndexOutOfBoundsException.class, () -> ArrayUtils.Remove(array, 3), "Should throw an IndexOutOfBoundsException.");
+        assertThrowsExactly(IndexOutOfBoundsException.class, () -> ArrayUtils.remove(array, 3),
+                "Should throw an IndexOutOfBoundsException.");
     }
 
     @Test
@@ -39,12 +41,12 @@ public class ArrayUtilsTest {
         Integer[] array1 = { 1, 2, 3 };
         Integer[] array2 = { 4, 5, 6 };
         Integer[] expected = { 1, 2, 3, 4, 5, 6 };
-        Integer[] result = ArrayUtils.Concatenate(array1, array2);
+        Integer[] result = ArrayUtils.concatenate(array1, array2);
         assertArrayEquals(expected, result);
 
         array2 = new Integer[0];
         expected = array1;
-        result = ArrayUtils.Concatenate(array1, array2);
+        result = ArrayUtils.concatenate(array1, array2);
         assertArrayEquals(expected, result);
     }
 
@@ -52,7 +54,7 @@ public class ArrayUtilsTest {
     void testReverse() {
         Integer[] array = { 1, 2, 3 };
         Integer[] expected = { 3, 2, 1 };
-        Integer[] result = ArrayUtils.Reverse(array);
+        Integer[] result = ArrayUtils.reverse(array);
         assertArrayEquals(expected, result);
     }
 


### PR DESCRIPTION
## Description of Changes

`toObjectArray` and `toPrimitiveArray` were added to convert between primitives and objects. 
Additional methods were added to all array utilities to handle primitive types.

## Verify

- [x] If code was changed, unit tests were added
- [x] If code was changed, the changes are documented in JavaDoc comments
- [x] If code was changed, it does not require external dependencies
- [x] The title uses the appropriate prefix (`chore`, `fix`, `feat`, `feat!`) for automatic versioning
- [x] All changes are listed in `release.md`.

## Reference

This resolves issue #20.
