### PR TITLE
fix: Write with append not working

### DIFF
--- a/release.md
+++ b/release.md
@@ -1,5 +1,3 @@
-# Primitive types support for array utilities
+# Fix append writing not working
 
-This update adds primitive type support to array utilities.
-
-Additionally all methods previously following a wrong naming convention (pascal case for static functions) now follow the java naming convention of camel case.
+`FileUtils.write(path, content, true)` throwing a StackOverflow exception is not fixed.

--- a/src/main/java/de/tinf/io/FileUtils.java
+++ b/src/main/java/de/tinf/io/FileUtils.java
@@ -33,10 +33,11 @@ public class FileUtils {
      * @param append  whether the content should be appended to the file
      * @throws RuntimeException if an I/O error occurs writing to the file
      */
-    public static void write(String content, String path, boolean append)
-            throws IOException {
+    public static void write(String content, String path, boolean append) {
         try {
-            createFile(path);
+            if (!exists(path)) {
+                createFile(path);
+            }
 
             if (append) {
                 Files.writeString(Path.of(path), content, StandardOpenOption.APPEND);

--- a/src/test/java/de/tinf/io/FileUtilsTest.java
+++ b/src/test/java/de/tinf/io/FileUtilsTest.java
@@ -126,4 +126,17 @@ class FileUtilsTest {
             FileUtils.delete(path);
         });
     }
+
+    @Test
+    void testAppendWriteFile() {
+        String path = "temp/appendFile.txt";
+
+        FileUtils.write("test", path, false);
+
+        assertDoesNotThrow(() -> {
+            FileUtils.write("test", path, true);
+        });
+
+        assertEquals("testtest", FileUtils.read(path));
+    }
 }


### PR DESCRIPTION
## Description of Changes

I changed the write function to check wether a file exists and only call `create` if file does not exist.

## Verify

- [x] If code was changed, unit tests were added
- [x] If code was changed, the changes are documented in JavaDoc comments
- [x] If code was changed, it does not require external dependencies
- [x] The title uses the appropriate prefix (`chore`, `fix`, `feat`, `feat!`) for automatic versioning
- [ ] All changes are listed in `release.md`.

## Reference

Resolves #28 
